### PR TITLE
add: deleteUserFromChannel controllers

### DIFF
--- a/backend/controllers/setup.go
+++ b/backend/controllers/setup.go
@@ -15,7 +15,7 @@ func SetupRouter() *gin.Engine {
 
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"*"},
-		AllowMethods:     []string{"GET" ,"POST", "PATCH", "DELETE"},
+		AllowMethods:     []string{"GET", "POST", "PATCH", "DELETE"},
 		AllowHeaders:     []string{"Origin", "Access-Control-Allow-Headers", "Content-Type", "Authorization"},
 		ExposeHeaders:    []string{"Content-Length"},
 		AllowCredentials: true,
@@ -38,6 +38,7 @@ func SetupRouter() *gin.Engine {
 	channel := api.Group("/channel")
 	channel.POST("/create/:workspace_id", CreateChannel)
 	channel.POST("/add_user/:workspace_id", AddUserInChannel)
+	channel.POST("/delete_user/:workspace_id", DeleteUserFromChannel)
 
 	return r
 }

--- a/backend/models/channels.go
+++ b/backend/models/channels.go
@@ -47,7 +47,7 @@ func (c *Channel) IsExistSameNameChannelInWorkspace(workspaceId int) (bool, erro
 	if err != nil {
 		return false, err
 	}
-	
+
 	cmd := fmt.Sprintf("SELECT name FROM %s WHERE id = ?", config.Config.ChannelsTableName)
 	for _, channelId := range channelIds {
 		row := DbConnection.QueryRow(cmd, channelId)
@@ -63,4 +63,10 @@ func (c *Channel) IsExistSameNameChannelInWorkspace(workspaceId int) (bool, erro
 	return false, nil
 }
 
-
+func GetChannelById(channelId int) (Channel, error) {
+	cmd := fmt.Sprintf("SELECT id, name, description, is_private, is_archive FROM %s WHERE id = ?", config.Config.ChannelsTableName)
+	row := DbConnection.QueryRow(cmd, channelId)
+	var c Channel
+	err := row.Scan(&c.ID, &c.Name, &c.Description, &c.IsPrivate, &c.IsArchive)
+	return c, err
+}

--- a/backend/models/channels_and_users.go
+++ b/backend/models/channels_and_users.go
@@ -53,3 +53,9 @@ func IsAdminUserInChannel(channelId int, userId uint32) bool {
 	}
 	return cnt == 1
 }
+
+func (cau *ChannelsAndUsers) DeleteUserFromChannel() error {
+	cmd := fmt.Sprintf("DELETE FROM %s WHERE channel_id = ? AND user_id = ?", config.Config.ChannelsAndUserTableName)
+	_, err := DbConnection.Exec(cmd, cau.ChannelId, cau.UserId)
+	return err
+}

--- a/backend/models/channels_and_users_test.go
+++ b/backend/models/channels_and_users_test.go
@@ -47,3 +47,31 @@ func TestIsAdminUserInChannel(t *testing.T) {
 	assert.Empty(t, cau.CreateChannelAndUsers())
 	assert.Equal(t, false, IsAdminUserInChannel(cau.ChannelId, cau.UserId))
 }
+
+func TestDeleteUserFromChannel(t *testing.T) {
+	cau := NewChannelsAndUses(9479923, 646433, true)
+	assert.Empty(t, cau.CreateChannelAndUsers())
+	assert.Empty(t, cau.DeleteUserFromChannel())
+
+	cau = NewChannelsAndUses(6464333, 79797, true)
+	assert.Empty(t, cau.CreateChannelAndUsers())
+	cau.IsAdmin = false
+	assert.Empty(t, cau.DeleteUserFromChannel())
+	assert.Equal(t, false, IsExistCAUByChannelIdAndUserId(cau.ChannelId, cau.UserId))
+
+	channelId := 37597692793
+	userId := uint32(35362622)
+	cau = NewChannelsAndUses(channelId, userId, true)
+	assert.Empty(t, cau.CreateChannelAndUsers())
+	assert.Equal(t, true, IsExistCAUByChannelIdAndUserId(channelId, userId))
+
+	cau.ChannelId = -1
+	assert.Empty(t, cau.DeleteUserFromChannel())
+	assert.Equal(t, true, IsExistCAUByChannelIdAndUserId(channelId, userId))
+
+	cau.ChannelId = channelId
+	assert.Empty(t, cau.DeleteUserFromChannel())
+	assert.Equal(t, false, IsExistCAUByChannelIdAndUserId(channelId, userId))
+
+
+}

--- a/backend/models/channels_test.go
+++ b/backend/models/channels_test.go
@@ -14,3 +14,19 @@ func TestCreateChannel(t *testing.T) {
 	c := NewChannel(0, name, description, is_private, is_archive)
 	assert.Empty(t, c.CreateChannel())
 }
+
+func TestGetChannelById(t *testing.T) {
+	name := "testGetChannelByIdName"
+	description := "testGetChannelByIdDescription"
+	is_private := true
+	is_archive := false
+	c := NewChannel(0, name, description, is_private, is_archive)
+	assert.Empty(t, c.CreateChannel())
+	assert.NotEqual(t, 0, c.ID)
+	c2, err := GetChannelById(c.ID)
+	assert.Empty(t, err)
+	assert.Equal(t, *c, c2)
+
+	_, err = GetChannelById(-1)
+	assert.NotEmpty(t, err)
+}

--- a/backend/models/workspace_and_users.go
+++ b/backend/models/workspace_and_users.go
@@ -61,3 +61,11 @@ func (wau *WorkspaceAndUsers) DeleteWorkspaceAndUser() error {
 	_, err := DbConnection.Exec(cmd, wau.WorkspaceId, wau.UserId, wau.RoleId)
 	return err
 }
+
+func GetRoleIdByWorkspaceIdAndUserId(workspaceId int, userId uint32) (int, error) {
+	cmd := fmt.Sprintf("SELECT role_id FROM %s WHERE workspace_id = ? AND user_id = ?", config.Config.WorkspaceAndUserTableName)
+	row := DbConnection.QueryRow(cmd, workspaceId, userId)
+	var roleId int
+	err := row.Scan(&roleId)
+	return roleId, err
+}

--- a/backend/models/workspace_and_users_test.go
+++ b/backend/models/workspace_and_users_test.go
@@ -74,3 +74,14 @@ func TestDeleteWorkspaceAndUser(t *testing.T) {
 		}
 	}
 }
+
+func TestGetRoleIdByWorkspaceIdAndUserId(t *testing.T) {
+	wau := NewWorkspaceAndUsers(37598379769, uint32(793457957), 3)
+	wau.Create()
+	roleId, err := GetRoleIdByWorkspaceIdAndUserId(wau.WorkspaceId, wau.UserId)
+	assert.Equal(t, wau.RoleId, roleId)
+	assert.Empty(t, err)
+
+	_, err = GetRoleIdByWorkspaceIdAndUserId(-1, wau.UserId)
+	assert.NotEmpty(t, err)
+}


### PR DESCRIPTION
channelからuserを削除するAPIを作成

権限については下記を参照

https://slack.com/intl/ja-jp/help/articles/201898668-%E3%83%81%E3%83%A3%E3%83%B3%E3%83%8D%E3%83%AB%E3%81%8B%E3%82%89%E3%83%A1%E3%83%B3%E3%83%90%E3%83%BC%E3%82%92%E5%A4%96%E3%81%99

private channelはchannelに所属してること、public channelはworkspaceの管理権限を持っていることが条件らしい