### PR TITLE
fix: testで使うデータをランダム生成する

### DIFF
--- a/backend/controllerUtils/check_existing_test.go
+++ b/backend/controllerUtils/check_existing_test.go
@@ -2,10 +2,10 @@ package controllerUtils
 
 import (
 	"math/rand"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xyproto/randomstring"
 
 	"backend/models"
 )
@@ -15,14 +15,14 @@ func TestIsExistCAUByChannelIdAndUserId(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	cau := models.NewChannelsAndUses(27393769379, uint32(593593926), false)
+	cau := models.NewChannelsAndUses(rand.Int(), rand.Uint32(), false)
 	assert.Empty(t, cau.Create())
 
 	b, err := IsExistCAUByChannelIdAndUserId(cau.ChannelId, cau.UserId)
 	assert.Equal(t, true, b)
 	assert.Empty(t, err)
 
-	b, err = IsExistCAUByChannelIdAndUserId(-1, cau.UserId)
+	b, err = IsExistCAUByChannelIdAndUserId(rand.Int(), cau.UserId)
 	assert.Equal(t, false, b)
 	assert.NotEmpty(t, err)
 }
@@ -33,7 +33,7 @@ func TestIsExistUserSameUsernameAndPassword(t *testing.T) {
 	}
 	names := make([]string, 10)
 	for i := 0; i < 10; i++ {
-		names[i] = "testIsExistUserSameUsernameAndPasswordUsername" + strconv.Itoa(i)
+		names[i] = randomstring.EnglishFrequencyString(30)
 	}
 
 	for _, name := range names {
@@ -52,10 +52,10 @@ func TestIsExistWorkspaceAndUser(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	w := models.NewWorkspace(0, "testIsExistWorkspaceAndUser", 4)
+	w := models.NewWorkspace(0, randomstring.EnglishFrequencyString(30), 4)
 	w.Create()
 	assert.Equal(t, true, IsExistWorkspaceById(w.ID))
-	assert.Equal(t, false, IsExistWorkspaceById(-1))
+	assert.Equal(t, false, IsExistWorkspaceById(rand.Int()))
 }
 
 func TestIsExistWAUByWorkspaceIdAndUserId(t *testing.T) {

--- a/backend/controllers/channel_test.go
+++ b/backend/controllers/channel_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xyproto/randomstring"
 
 	"backend/controllerUtils"
 	"backend/models"
@@ -78,13 +79,13 @@ func TestCreateChannel(t *testing.T) {
 	// 5. すでに同じ名前のchannelが対象のworkspaceに存在している場合 409
 
 	t.Run("1", func(t *testing.T) {
-		userName := "testCreateChannelUserName1"
-		workspaceName := "testCreateChannelWorkspaceName1"
-		channelName := "testCreateChannelName1"
-		description := "description1"
+		userName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
+		description := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
-		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code, "OK")
+		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
 
 		rr := loginTestFunc(userName, "pass")
 		assert.Equal(t, http.StatusOK, rr.Code)
@@ -110,10 +111,10 @@ func TestCreateChannel(t *testing.T) {
 	})
 
 	t.Run("3", func(t *testing.T) {
-		userName := "testCreateChannelUserName3"
-		workspaceName := "testCreateChannelWorkspaceName3"
-		channelName := "testCreateChannelName3"
-		description := "description3"
+		userName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
+		description := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -143,11 +144,11 @@ func TestCreateChannel(t *testing.T) {
 	})
 
 	t.Run("4", func(t *testing.T) {
-		userName := "testCreateChannelUserName4"
-		createWorkspaceUserName := "testCreateChannelCreateWorkspaceUserName4"
-		workspaceName := "testCreateChannelWorkspaceName4"
-		channelName := "testCreateChannelName4"
-		description := "description4"
+		userName := randomstring.EnglishFrequencyString(30)
+		createWorkspaceUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
+		description := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -177,10 +178,10 @@ func TestCreateChannel(t *testing.T) {
 	})
 
 	t.Run("5", func(t *testing.T) {
-		userName := "testCreateChannelUserName5"
-		workspaceName := "testCreateChannelWorkspaceName5"
-		channelName := "testCreateChannelName5"
-		description := "description5"
+		userName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
+		description := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -218,10 +219,10 @@ func TestAddUserInChannel(t *testing.T) {
 	// 7. リクエストしたuserにチャンネルの管理権限がない場合 403
 
 	t.Run("1", func(t *testing.T) {
-		requestUserName := "testAddUserInChannelRequestUserName1"
-		addUserName := "testAddUserInChannelAddUserName1"
-		workspaceName := "testAddUserInChannelWorkspaceName1"
-		channelName := "testAddUserInChannelChannelName1"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -264,10 +265,10 @@ func TestAddUserInChannel(t *testing.T) {
 	})
 
 	t.Run("2", func(t *testing.T) {
-		requestUserName := "testAddUserInChannelRequestUserName2"
-		addUserName := "testAddUserInChannelAddUserName2"
-		workspaceName := "testAddUserInChannelWorkspaceName2"
-		channelName := "testAddUserInChannelChannelName2"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -309,11 +310,11 @@ func TestAddUserInChannel(t *testing.T) {
 	})
 
 	t.Run("3", func(t *testing.T) {
-		requestUserName := "testAddUserInChannelRequestUserName3"
-		addUserName := "testAddUserInChannelAddUserName3"
-		createWorkspaceUserName := "testAddUserInChannelCreateWorkspaceUserName3"
-		workspaceName := "testAddUserInChannelWorkspaceName3"
-		channelName := "testAddUserInChannelChannelName3"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		createWorkspaceUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -359,10 +360,10 @@ func TestAddUserInChannel(t *testing.T) {
 	})
 
 	t.Run("4", func(t *testing.T) {
-		requestUserName := "testAddUserInChannelRequestUserName4"
-		addUserName := "testAddUserInChannelAddUserName4"
-		workspaceName := "testAddUserInChannelWorkspaceName4"
-		channelName := "testAddUserInChannelChannelName4"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -398,10 +399,10 @@ func TestAddUserInChannel(t *testing.T) {
 	})
 
 	t.Run("6", func(t *testing.T) {
-		requestUserName := "testAddUserInChannelRequestUserName6"
-		addUserName := "testAddUserInChannelAddUserName6"
-		workspaceName := "testAddUserInChannelWorkspaceName6"
-		channelName := "testAddUserInChannelChannelName6"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -442,11 +443,11 @@ func TestAddUserInChannel(t *testing.T) {
 	})
 
 	t.Run("7", func(t *testing.T) {
-		requestUserName := "testAddUserInChannelRequestUserName7"
-		addUserName := "testAddUserInChannelAddUserName7"
-		createChannelUserName := "testAddUserInChannelCreateUserName7"
-		workspaceName := "testAddUserInChannelWorkspaceName7"
-		channelName := "testAddUserInChannelChannelName7"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		createChannelUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -515,10 +516,10 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	// 12. channelがアーカイブされている場合 400
 
 	t.Run("1", func(t *testing.T) {
-		requestUserName := "testDeleteUserFromChannelRequestUserName1"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName1"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName1"
-		channelName := "testDeleteUserFromChannelName1"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -562,10 +563,10 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	})
 
 	t.Run("2", func(t *testing.T) {
-		requestUserName := "testDeleteUserFromChannelRequestUserName2"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName2"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName2"
-		channelName := "testDeleteUserFromChannelName2"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -609,10 +610,10 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	})
 
 	t.Run("3", func(t *testing.T) {
-		requestUserName := "testDeleteUserFromChannelRequestUserName3"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName3"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName3"
-		channelName := "testDeleteUserFromChannelName3"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -655,10 +656,10 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	})
 
 	t.Run("4", func(t *testing.T) {
-		requestUserName := "testDeleteUserFromChannelRequestUserName4"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName4"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName4"
-		channelName := "testDeleteUserFromChannelName4"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -694,11 +695,11 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	})
 
 	t.Run("5", func(t *testing.T) {
-		createChannelUserName := "testDeleteUserFromChannelCreateChannelUserName5"
-		requestUserName := "testDeleteUserFromChannelRequestUserName5"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName5"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName5"
-		channelName := "testDeleteUserFromChannelName5"
+		createChannelUserName := randomstring.EnglishFrequencyString(30)
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(createChannelUserName, "pass").Code)
@@ -745,10 +746,10 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	})
 
 	t.Run("6", func(t *testing.T) {
-		requestUserName := "testDeleteUserFromChannelRequestUserName6"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName6"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName6"
-		channelName := "testDeleteUserFromChannelName6"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -788,11 +789,11 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	})
 
 	t.Run("7", func(t *testing.T) {
-		requestUserName := "testDeleteUserFromChannelRequestUserNam7"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName7"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName7"
-		workspaceName2 := "testDeleteUserFromChannelWorkspaceName7.2"
-		channelName := "testDeleteUserFromChannelName7"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		workspaceName2 := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -882,10 +883,10 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	})
 
 	t.Run("9", func(t *testing.T) {
-		requestUserName := "testDeleteUserFromChannelRequestUserName9"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName9"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName9"
-		channelName := "testDeleteUserFromChannelName9"
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -923,11 +924,11 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	})
 
 	t.Run("10", func(t *testing.T) {
-		createChannelUserName := "testDeleteUserFromChannelCreateChannelUserName10"
-		requestUserName := "testDeleteUserFromChannelRequestUserName10"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName10"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName10"
-		channelName := "testDeleteUserFromChannelName10"
+		createChannelUserName := randomstring.EnglishFrequencyString(30)
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(createChannelUserName, "pass").Code)
@@ -975,11 +976,11 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	})
 
 	t.Run("11", func(t *testing.T) {
-		createChannelUserName := "testDeleteUserFromChannelCreateChannelUserName11"
-		requestUserName := "testDeleteUserFromChannelRequestUserName11"
-		deleteUserName := "testDeleteUserFromChannelDeleteUserName11"
-		workspaceName := "testDeleteUserFromChannelWorkspaceName11"
-		channelName := "testDeleteUserFromChannelName11"
+		createChannelUserName := randomstring.EnglishFrequencyString(30)
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(createChannelUserName, "pass").Code)
@@ -1043,11 +1044,10 @@ func TestDeleteChannel(t *testing.T) {
 	// 6. channelがworkspaceに存在しない場合 404
 
 	t.Run("1", func(t *testing.T) {
-		testNumber := "1"
-		requestUserName := "testDeleteChannelFromWorkspaceRequestUserName" + testNumber
-		inChannelUserName := "testDeleteChannelFromWorkspaceInChannelUserName" + testNumber
-		workspaceName := "testDeleteChannelFromWorkspaceName" + testNumber
-		channelName := "testDeleteChannelFromWorkspaceChannelName" + testNumber
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		inChannelUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -1092,11 +1092,10 @@ func TestDeleteChannel(t *testing.T) {
 	})
 
 	t.Run("2", func(t *testing.T) {
-		testNumber := "2"
-		requestUserName := "testDeleteChannelFromWorkspaceRequestUserName" + testNumber
-		inChannelUserName := "testDeleteChannelFromWorkspaceInChannelUserName" + testNumber
-		workspaceName := "testDeleteChannelFromWorkspaceName" + testNumber
-		channelName := "testDeleteChannelFromWorkspaceChannelName" + testNumber
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		inChannelUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -1140,12 +1139,11 @@ func TestDeleteChannel(t *testing.T) {
 	})
 
 	t.Run("3", func(t *testing.T) {
-		testNumber := "3"
-		requestUserName := "testDeleteChannelFromWorkspaceRequestUserName" + testNumber
-		inChannelUserName := "testDeleteChannelFromWorkspaceInChannelUserName" + testNumber
-		createChannelUserName := "testDeleteChannelFromWorkspaceCreateChannelUserName" + testNumber
-		workspaceName := "testDeleteChannelFromWorkspaceName" + testNumber
-		channelName := "testDeleteChannelFromWorkspaceChannelName" + testNumber
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		inChannelUserName := randomstring.EnglishFrequencyString(30)
+		createChannelUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -1192,11 +1190,10 @@ func TestDeleteChannel(t *testing.T) {
 	})
 
 	t.Run("4", func(t *testing.T) {
-		testNumber := "4"
-		requestUserName := "testDeleteChannelFromWorkspaceRequestUserName" + testNumber
-		inChannelUserName := "testDeleteChannelFromWorkspaceInChannelUserName" + testNumber
-		workspaceName := "testDeleteChannelFromWorkspaceName" + testNumber
-		channelName := "testDeleteChannelFromWorkspaceChannelName" + testNumber
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		inChannelUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -1236,10 +1233,9 @@ func TestDeleteChannel(t *testing.T) {
 	})
 
 	t.Run("5", func(t *testing.T) {
-		testNumber := "5"
-		requestUserName := "testDeleteChannelFromWorkspaceRequestUserName" + testNumber
-		inChannelUserName := "testDeleteChannelFromWorkspaceInChannelUserName" + testNumber
-		workspaceName := "testDeleteChannelFromWorkspaceName" + testNumber
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		inChannelUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
 		assert.Equal(t, http.StatusOK, signUpTestFunc(inChannelUserName, "pass").Code)
@@ -1270,12 +1266,11 @@ func TestDeleteChannel(t *testing.T) {
 	})
 
 	t.Run("6", func(t *testing.T) {
-		testNumber := "6"
-		requestUserName := "testDeleteChannelFromWorkspaceRequestUserName" + testNumber
-		inChannelUserName := "testDeleteChannelFromWorkspaceInChannelUserName" + testNumber
-		workspaceName := "testDeleteChannelFromWorkspaceName" + testNumber
-		workspaceName2 := "testDeleteChannelFromWorkspaceName" + testNumber + "2"
-		channelName := "testDeleteChannelFromWorkspaceChannelName" + testNumber
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		inChannelUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		workspaceName2 := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)
@@ -1322,26 +1317,25 @@ func TestDeleteChannel(t *testing.T) {
 }
 
 func TestGetChannelsByUser(t *testing.T) {
-	// if testing.Short() {
-	// 	t.Skip("skipping test in short mode.")
-	// }
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 
 	// 1. general channel以外のchannelが存在する場合 200
 	// 2. userがworkspaceに存在していない場合 404
 
 	t.Run("1 データが存在する場合", func(t *testing.T) {
-		testNum := "1"
 		channelCount := 10
-		userName := "testGetChannelsByUser" + testNum
-		workspaceName1 := "testGetChannelsByUserWorkspaceName" + testNum + ".1"
-		workspaceName2 := "testGetChannelsByUserWorkspaceName" + testNum + ".2"
+		userName := randomstring.EnglishFrequencyString(30)
+		workspaceName1 := randomstring.EnglishFrequencyString(30)
+		workspaceName2 := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 		channelNames1 := make([]string, channelCount)
 		channelNames2 := make([]string, channelCount)
 
 		for i := 0; i < channelCount; i++ {
-			channelNames1[i] = "testGetChannelsByUserChannelName" + strconv.Itoa(i) + ".1"
-			channelNames2[i] = "testGetChannelsByUserChannelName" + strconv.Itoa(i) + ".2"
+			channelNames1[i] = randomstring.EnglishFrequencyString(30)
+			channelNames2[i] = randomstring.EnglishFrequencyString(30)
 		}
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -1398,16 +1392,15 @@ func TestGetChannelsByUser(t *testing.T) {
 	})
 
 	t.Run("2 userがworkspaceに存在していない場合", func(t *testing.T) {
-		testNum := "2"
 		channelCount := 10
-		userName1 := "testGetChannelsByUser" + testNum + ".1"
-		userName2 := "testGetChannelsByUser" + testNum + ".2"
-		workspaceName := "testGetChannelsByUserWorkspaceName" + testNum
+		userName1 := randomstring.EnglishFrequencyString(30)
+		userName2 := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 		channelNames := make([]string, channelCount)
 
 		for i := 0; i < channelCount; i++ {
-			channelNames[i] = "testGetChannelsByUserChannelName" + strconv.Itoa(i)
+			channelNames[i] = randomstring.EnglishFrequencyString(30)
 		}
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName1, "pass").Code)
@@ -1445,5 +1438,4 @@ func TestGetChannelsByUser(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 		assert.Equal(t, "{\"message\":\"request user not found in workspace\"}", rr.Body.String())
 	})
-
 }

--- a/backend/controllers/message_test.go
+++ b/backend/controllers/message_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xyproto/randomstring"
 
 	"backend/controllerUtils"
 	"backend/models"
@@ -55,11 +56,10 @@ func TestSendMessage(t *testing.T) {
 	// 4. channelにuserが存在しない場合 404
 
 	t.Run("1 正常な場合", func(t *testing.T) {
-		testCaseNum := "1"
-		userName := "testSendMessageUserName" + testCaseNum
-		workspaceName := "testSendMessageWorkspaceName" + testCaseNum
-		channelName := "testSendMessageChannelName" + testCaseNum
-		text := "testSendMessageText" + testCaseNum
+		userName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
+		text := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -95,11 +95,10 @@ func TestSendMessage(t *testing.T) {
 	})
 
 	t.Run("2 bodyに不足がある場合", func(t *testing.T) {
-		testCaseNum := "2"
-		userName := "testSendMessageUserName" + testCaseNum
-		workspaceName := "testSendMessageWorkspaceName" + testCaseNum
-		channelName := "testSendMessageChannelName" + testCaseNum
-		text := "testSendMessageText" + testCaseNum
+		userName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
+		text := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -132,13 +131,12 @@ func TestSendMessage(t *testing.T) {
 	})
 
 	t.Run("3 userとchannelが同じworkspaceに存在していない場合", func(t *testing.T) {
-		testCaseNum := "3"
-		userName := "testSendMessageUserName" + testCaseNum
-		userName2 := "testSendMessageUserName" + testCaseNum + ".2"
-		workspaceName := "testSendMessageWorkspaceName" + testCaseNum
-		workspaceName2 := "testSendMessageWorkspaceName" + testCaseNum + ".2"
-		channelName := "testSendMessageChannelName" + testCaseNum
-		text := "testSendMessageText" + testCaseNum
+		userName := randomstring.EnglishFrequencyString(30)
+		userName2 := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		workspaceName2 := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
+		text := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -179,12 +177,11 @@ func TestSendMessage(t *testing.T) {
 		assert.Equal(t, "{\"message\":\"channel and user not found in same workspace\"}", rr.Body.String())
 	})
 	t.Run("4 channelにuserが存在しない場合", func(t *testing.T) {
-		testCaseNum := "4"
-		userName := "testSendMessageUserName" + testCaseNum
-		userName2 := "testSendMessageUserName" + testCaseNum + ".2"
-		workspaceName := "testSendMessageWorkspaceName" + testCaseNum
-		channelName := "testSendMessageChannelName" + testCaseNum
-		text := "testSendMessageText" + testCaseNum
+		userName := randomstring.EnglishFrequencyString(30)
+		userName2 := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
+		text := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -232,12 +229,11 @@ func TestGetAllMessagesFromChannel(t *testing.T) {
 	// 3. userがchannelに所属していない場合 404
 
 	t.Run("1 messageが存在する場合", func(t *testing.T) {
-		testNum := "1"
-		userName := "testGetAllMessageFromChannelUserName" + testNum
-		workspaceName := "testGetAllMessageFromChannelWorkspaceName" + testNum
-		channelName := "testGetAllMessageFromChannelName" + testNum
+		userName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
-		text := "testGetAllMessageFromChannelText" + testNum
+		text := randomstring.EnglishFrequencyString(30)
 		messageCount := 10
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -287,10 +283,9 @@ func TestGetAllMessagesFromChannel(t *testing.T) {
 	})
 
 	t.Run("2 messageが存在しない場合", func(t *testing.T) {
-		testNum := "2"
-		userName := "testGetAllMessageFromChannelUserName" + testNum
-		workspaceName := "testGetAllMessageFromChannelWorkspaceName" + testNum
-		channelName := "testGetAllMessageFromChannelName" + testNum
+		userName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -322,13 +317,12 @@ func TestGetAllMessagesFromChannel(t *testing.T) {
 	})
 
 	t.Run("3 userがchannelに所属していない場合", func(t *testing.T) {
-		testNum := "3"
-		userName := "testGetAllMessageFromChannelUserName" + testNum
-		userName2 := "testGetAllMessageFromChannelUserName" + testNum + ".2"
-		workspaceName := "testGetAllMessageFromChannelWorkspaceName" + testNum
-		channelName := "testGetAllMessageFromChannelName" + testNum
+		userName := randomstring.EnglishFrequencyString(30)
+		userName2 := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
+		channelName := randomstring.EnglishFrequencyString(30)
 		isPrivate := true
-		text := "testGetAllMessageFromChannelText" + testNum
+		text := randomstring.EnglishFrequencyString(30)
 		messageCount := 3
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)

--- a/backend/controllers/user_test.go
+++ b/backend/controllers/user_test.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xyproto/randomstring"
 
-	"backend/models"
 	"backend/controllerUtils"
+	"backend/models"
 )
 
 var router = SetupRouter()
@@ -67,7 +68,7 @@ func TestLogin(t *testing.T) {
 		names := make([]string, 10)
 
 		for i := 0; i < 10; i++ {
-			names[i] = "loginControllerTestUser1" + strconv.Itoa(i)
+			names[i] = randomstring.EnglishFrequencyString(30)
 		}
 
 		for i := 0; i < 10; i++ {
@@ -91,15 +92,14 @@ func TestLogin(t *testing.T) {
 			assert.NotEmpty(t, lr.Token)
 			assert.Equal(t, names[i], lr.Username)
 			assert.Equal(t, ids[i], lr.UserId)
-
 		}
 	})
 	t.Run("2", func(t *testing.T) {
 		ids := make([]uint32, 10)
-		name := "testLoginUser2"
+		name := randomstring.EnglishFrequencyString(30)
 		passwords := make([]string, 10)
 		for i := 0; i < 10; i++ {
-			passwords[i] = "TestLoginPass2" + strconv.Itoa(i)
+			passwords[i] = randomstring.EnglishFrequencyString(30)
 		}
 		for i, pass := range passwords {
 			rr := signUpTestFunc(name, pass)
@@ -127,9 +127,8 @@ func TestLogin(t *testing.T) {
 	t.Run("3", func(t *testing.T) {
 		names := make([]string, 10)
 		for i := 0; i < 10; i++ {
-			name := "testLoginUser3" + strconv.Itoa(i)
-			names[i] = name
-			assert.Equal(t, http.StatusOK, signUpTestFunc(name, "pass").Code)
+			names[i] = randomstring.EnglishFrequencyString(30)
+			assert.Equal(t, http.StatusOK, signUpTestFunc(names[i], "pass").Code)
 		}
 		for i := 0; i < 10; i++ {
 			var rr *httptest.ResponseRecorder
@@ -147,7 +146,7 @@ func TestLogin(t *testing.T) {
 	t.Run("4", func(t *testing.T) {
 		names := make([]string, 10)
 		for i := 0; i < 10; i++ {
-			name := "testLoginUser4" + strconv.Itoa(i)
+			name := randomstring.EnglishFrequencyString(30)
 			if i%3 == 0 {
 				assert.Equal(t, http.StatusOK, signUpTestFunc(name, "pass").Code)
 			}
@@ -178,7 +177,7 @@ func TestSignUp(t *testing.T) {
 	// 1
 	t.Run("1", func(t *testing.T) {
 		for i := 0; i < 10; i++ {
-			username := "testSignUpControllerUser1" + strconv.Itoa(i)
+			username := randomstring.EnglishFrequencyString(30)
 			password := "pass"
 			assert.Equal(t, http.StatusOK, signUpTestFunc(username, password).Code)
 		}
@@ -187,7 +186,7 @@ func TestSignUp(t *testing.T) {
 	// 2
 	t.Run("2", func(t *testing.T) {
 		for i := 0; i < 10; i++ {
-			username := "testSignUpControllerUser2"
+			username := randomstring.EnglishFrequencyString(30)
 			password := "password" + strconv.Itoa(i)
 			assert.Equal(t, http.StatusOK, signUpTestFunc(username, password).Code)
 		}
@@ -196,7 +195,7 @@ func TestSignUp(t *testing.T) {
 	// 3
 	t.Run("3", func(t *testing.T) {
 		for i := 0; i < 12; i++ {
-			username := "testSignUpControllerUser3" + strconv.Itoa(i)
+			username := randomstring.EnglishFrequencyString(30)
 			password := "pass"
 
 			var rr *httptest.ResponseRecorder
@@ -213,7 +212,7 @@ func TestSignUp(t *testing.T) {
 
 	// 4
 	t.Run("4", func(t *testing.T) {
-		username := "testSignUpControllerUser4"
+		username := randomstring.EnglishFrequencyString(30)
 		password := "pass"
 		rr := signUpTestFunc(username, password)
 		assert.Equal(t, http.StatusOK, rr.Code)

--- a/backend/controllers/workspace_test.go
+++ b/backend/controllers/workspace_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xyproto/randomstring"
 
 	"backend/controllerUtils"
 	"backend/models"
@@ -89,9 +90,9 @@ func GetUsersInWorkspaceTestFunc(workspaceId int, jwtToken string) *httptest.Res
 }
 
 func TestCreateWorkspace(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
+	// if testing.Short() {
+	// 	t.Skip("skipping test in short mode.")
+	// }
 
 	// 1. 正常な状態(ログイン中のユーザーがworkspaceを作成する) 200
 	// 2. jwtTokenから復元されるUserIdとbodyのprimaryOwnerUserIdが一致しない場合 400
@@ -105,11 +106,11 @@ func TestCreateWorkspace(t *testing.T) {
 		JwtTokens := []string{}
 
 		for i := 0; i < 10; i++ {
-			UserNames = append(UserNames, "createWorkSpaceTestUserName1"+strconv.Itoa(i))
+			UserNames = append(UserNames, randomstring.EnglishFrequencyString(30))
 		}
 
 		for i := 0; i < 100; i++ {
-			WorkSpaceNames = append(WorkSpaceNames, "createWorkspaceTestWorkspaceNames1"+strconv.Itoa(i))
+			WorkSpaceNames = append(WorkSpaceNames, randomstring.EnglishFrequencyString(30))
 		}
 
 		for _, name := range UserNames {
@@ -144,11 +145,11 @@ func TestCreateWorkspace(t *testing.T) {
 		jwtTokens := []string{}
 
 		for i := 0; i < 10; i++ {
-			UserNames = append(UserNames, "createWorkSpaceTestUserName2"+strconv.Itoa(i))
+			UserNames = append(UserNames, randomstring.EnglishFrequencyString(30))
 		}
 
 		for i := 0; i < 100; i++ {
-			WorkSpaceNames = append(WorkSpaceNames, "createWorkspaceTestWorkspaceNames2"+strconv.Itoa(i))
+			WorkSpaceNames = append(WorkSpaceNames, randomstring.EnglishFrequencyString(30))
 		}
 
 		for _, name := range UserNames {
@@ -185,11 +186,11 @@ func TestCreateWorkspace(t *testing.T) {
 		jwtTokens := []string{}
 
 		for i := 0; i < 10; i++ {
-			UserNames = append(UserNames, "createWorkSpaceTestUserName3"+strconv.Itoa(i))
+			UserNames = append(UserNames, randomstring.EnglishFrequencyString(30))
 		}
 
 		for i := 0; i < 100; i++ {
-			WorkSpaceNames = append(WorkSpaceNames, "createWorkspaceTestWorkspaceNames3"+strconv.Itoa(i))
+			WorkSpaceNames = append(WorkSpaceNames, randomstring.EnglishFrequencyString(30))
 		}
 
 		for i, name := range UserNames {
@@ -239,9 +240,9 @@ func TestAddUserInWorkspace(t *testing.T) {
 
 	// 1
 	t.Run("1", func(t *testing.T) {
-		ownerUserName := "AddUserInWorkspaceTestOwnerUser1"
-		addUserName := "AddUserInWorkspaceTestUser1"
-		workspaceName := "AddUserInWorkspaceTestWorkspace1"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		addUserRoleId := 4
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
@@ -277,9 +278,9 @@ func TestAddUserInWorkspace(t *testing.T) {
 	})
 
 	t.Run("2", func(t *testing.T) {
-		ownerUserName := "AddUserInWorkspaceTestOwnerUser2"
-		addUserName := "AddUserInWorkspaceTestUser2"
-		workspaceName := "AddUserInWorkspaceTestWorkspace2"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
 
@@ -309,9 +310,9 @@ func TestAddUserInWorkspace(t *testing.T) {
 	})
 
 	t.Run("3", func(t *testing.T) {
-		ownerUserName := "AddUserInWorkspaceTestOwnerUser3"
-		addUserName := "AddUserInWorkspaceTestUser3"
-		workspaceName := "AddUserInWorkspaceTestWorkspace3"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		addUserRoleId := 4
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
@@ -336,16 +337,16 @@ func TestAddUserInWorkspace(t *testing.T) {
 		w := new(models.Workspace)
 		json.Unmarshal(([]byte)(byteArray), w)
 
-		rr = addUserWorkspaceTestFunc(10000000000000000, addUserRoleId, alr.UserId, olr.Token)
+		rr = addUserWorkspaceTestFunc(rand.Int(), addUserRoleId, alr.UserId, olr.Token)
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 		assert.Equal(t, "{\"message\":\"workspace not found\"}", rr.Body.String())
 	})
 
 	t.Run("4", func(t *testing.T) {
-		ownerUserName := "AddUserInWorkspaceTestOwnerUser4"
-		reqUserName := "reqUserInWorkspaceTestReqUser4"
-		addUserName := "AddUserInWorkspaceTestUser4"
-		workspaceName := "AddUserInWorkspaceTestWorkspace4"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		reqUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		addUserRoleId := 4
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
@@ -394,9 +395,9 @@ func TestAddUserInWorkspace(t *testing.T) {
 	})
 
 	t.Run("5", func(t *testing.T) {
-		ownerUserName := "AddUserInWorkspaceTestOwnerUser5"
-		addUserName := "AddUserInWorkspaceTestUser5"
-		workspaceName := "AddUserInWorkspaceTestWorkspace5"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		addUserRoleId := 1
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
@@ -427,9 +428,9 @@ func TestAddUserInWorkspace(t *testing.T) {
 	})
 
 	t.Run("6", func(t *testing.T) {
-		ownerUserName := "AddUserInWorkspaceTestOwnerUser6"
-		addUserName := "AddUserInWorkspaceTestUser6"
-		workspaceName := "AddUserInWorkspaceTestWorkspace6"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		addUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		addUserRoleId := 4
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
@@ -494,9 +495,9 @@ func TestDeleteUserFromWorkSpace(t *testing.T) {
 
 	// 1
 	t.Run("1", func(t *testing.T) {
-		ownerUserName := "deleteUserFromWorkspaceTestOwnerUser1"
-		deleteUserName := "deleteUserFromWorkspaceTestUser1"
-		workspaceName := "deleteUserFromWorkspaceTestWorkspace1"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		deleteUserRoleId := 4
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
@@ -535,9 +536,9 @@ func TestDeleteUserFromWorkSpace(t *testing.T) {
 
 	// 2
 	t.Run("2", func(t *testing.T) {
-		ownerUserName := "deleteUserFromWorkspaceTestOwnerUser2"
-		deleteUserName := "deleteUserFromWorkspaceTestUser2"
-		workspaceName := "deleteUserFromWorkspaceTestWorkspace2"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		deleteUserRoleId := 4
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
@@ -575,10 +576,10 @@ func TestDeleteUserFromWorkSpace(t *testing.T) {
 
 	// 3
 	t.Run("3", func(t *testing.T) {
-		ownerUserName := "deleteUserFromWorkspaceTestOwnerUser3"
-		reqUserName := "deleteUserFromWorkspaceTestReqUser3"
-		deleteUserName := "deleteUserFromWorkspaceTestUser3"
-		workspaceName := "deleteUserFromWorkspaceTestWorkspace3"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		reqUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		deleteUserRoleId := 4
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
@@ -622,9 +623,9 @@ func TestDeleteUserFromWorkSpace(t *testing.T) {
 
 	//4
 	t.Run("4", func(t *testing.T) {
-		ownerUserName := "deleteUserFromWorkspaceTestOwnerUser4"
-		reqUserName := "deleteUserFromWorkspaceTestReqUser4"
-		workspaceName := "deleteUserFromWorkspaceTestWorkspace4"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		reqUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
 
@@ -657,9 +658,9 @@ func TestDeleteUserFromWorkSpace(t *testing.T) {
 
 	// 5
 	t.Run("5", func(t *testing.T) {
-		ownerUserName := "deleteUserFromWorkspaceTestOwnerUser5"
-		deleteUserName := "deleteUserFromWorkspaceTestUser5"
-		workspaceName := "deleteUserFromWorkspaceTestWorkspace5"
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		deleteUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 		deleteUserRoleId := 4
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
@@ -705,13 +706,12 @@ func TestGetWorkspacesById(t *testing.T) {
 	// 2. workspaceが存在しない場合 200
 
 	t.Run("1 workspaceが存在する場合", func(t *testing.T) {
-		testNum := "1"
 		workspaceCount := 10
-		userName := "testGetWorkspaceByIdUserName" + testNum
+		userName := randomstring.EnglishFrequencyString(30)
 		workspaceNames := make([]string, workspaceCount)
 		workspaces := make([]models.Workspace, workspaceCount)
 		for i := 0; i < workspaceCount; i++ {
-			workspaceNames[i] = "testGetWorkspaceByIdWorkspaceName" + testNum + "." + strconv.Itoa(i)
+			workspaceNames[i] = randomstring.EnglishFrequencyString(30)
 		}
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
@@ -751,8 +751,7 @@ func TestGetWorkspacesById(t *testing.T) {
 	})
 
 	t.Run("2 workspaceが存在しない場合", func(t *testing.T) {
-		testNum := "2"
-		userName := "testGetWorkspaceByIdUserName" + testNum
+		userName := randomstring.EnglishFrequencyString(30)
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(userName, "pass").Code)
 
@@ -782,11 +781,10 @@ func TestGetUsersInWorkspace(t *testing.T) {
 	// 2. workspaceにいないuserからのアクセスだった場合 404
 
 	t.Run("1 正常な場合", func(t *testing.T) {
-		testNum := "1"
 		userCount := 10
-		ownerUserName := "testGetUsersInWorkspaceNameOwnerUserName" + testNum
+		ownerUserName := randomstring.EnglishFrequencyString(30)
 		userInfos := make([]controllerUtils.UserInfoInWorkspace, userCount)
-		workspaceName := "testGetUsersInWorkspaceName" + testNum
+		workspaceName := randomstring.EnglishFrequencyString(30)
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
 
@@ -799,7 +797,7 @@ func TestGetUsersInWorkspace(t *testing.T) {
 		for i := 0; i < userCount; i++ {
 			userInfos[i] = controllerUtils.UserInfoInWorkspace{
 				ID:     0,
-				Name:   "testGetUserInWorkspaceUserName" + testNum + "." + strconv.Itoa(i),
+				Name:   randomstring.EnglishFrequencyString(30),
 				RoleId: rand.Int()%3 + 2,
 			}
 
@@ -846,10 +844,9 @@ func TestGetUsersInWorkspace(t *testing.T) {
 	})
 
 	t.Run("2 workspaceにいないuserからのアクセスの場合", func(t *testing.T) {
-		testNum := "2"
-		ownerUserName := "testGetUsersInWorkspaceNameOwnerUserName" + testNum
-		requestUserName := "testGetUsersInWorkspaceRequestUserName" + testNum
-		workspaceName := "testGetUsersInWorkspaceName" + testNum
+		ownerUserName := randomstring.EnglishFrequencyString(30)
+		requestUserName := randomstring.EnglishFrequencyString(30)
+		workspaceName := randomstring.EnglishFrequencyString(30)
 
 		assert.Equal(t, http.StatusOK, signUpTestFunc(ownerUserName, "pass").Code)
 		assert.Equal(t, http.StatusOK, signUpTestFunc(requestUserName, "pass").Code)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
+	github.com/xyproto/randomstring v1.0.5 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -73,6 +73,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/backend/models/channels_and_users_test.go
+++ b/backend/models/channels_and_users_test.go
@@ -11,8 +11,8 @@ func TestCreateChannelAndUsers(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	channelId := 5553155345262
-	userId := uint32(452526)
+	channelId := rand.Int()
+	userId := rand.Uint32()
 	isAdmin := true
 
 	cau := NewChannelsAndUses(channelId, userId, isAdmin)
@@ -21,11 +21,11 @@ func TestCreateChannelAndUsers(t *testing.T) {
 	cau.IsAdmin = false
 	assert.NotEmpty(t, cau.Create())
 
-	cau.ChannelId = 5347595792
+	cau.ChannelId = rand.Int()
 	assert.Empty(t, cau.Create())
 
 	cau.ChannelId = channelId
-	cau.UserId = 53534626
+	cau.UserId = rand.Uint32()
 	assert.Empty(t, cau.Create())
 }
 
@@ -34,8 +34,8 @@ func TestGetCAUByChannelIdAndUserId(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	channelId := 7592792472623
-	userId := uint32(137201051)
+	channelId := rand.Int()
+	userId := rand.Uint32()
 
 	cau := NewChannelsAndUses(channelId, userId, false)
 	assert.Empty(t, cau.Create())
@@ -52,8 +52,8 @@ func TestIsExistCAUByChannelIdAndUserId(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	channelId := 532446463423234
-	userId := uint32(3535422)
+	channelId := rand.Int()
+	userId := rand.Uint32()
 
 	cau := NewChannelsAndUses(channelId, userId, false)
 	assert.Empty(t, cau.Create())
@@ -66,13 +66,13 @@ func TestIsAdminUserInChannel(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	cau := NewChannelsAndUses(532446463423234434, uint32(53663732), true)
+	cau := NewChannelsAndUses(rand.Int(), rand.Uint32(), true)
 	assert.Empty(t, cau.Create())
 
 	assert.Equal(t, true, IsAdminUserInChannel(cau.ChannelId, cau.UserId))
-	assert.Equal(t, false, IsAdminUserInChannel(cau.ChannelId, 46433))
+	assert.Equal(t, false, IsAdminUserInChannel(cau.ChannelId, rand.Uint32()))
 
-	cau = NewChannelsAndUses(cau.ChannelId, 5236632, false)
+	cau = NewChannelsAndUses(cau.ChannelId, rand.Uint32(), false)
 	assert.Empty(t, cau.Create())
 	assert.Equal(t, false, IsAdminUserInChannel(cau.ChannelId, cau.UserId))
 }
@@ -81,18 +81,18 @@ func TestDeleteUserFromChannel(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	cau := NewChannelsAndUses(9479923, 646433, true)
+	cau := NewChannelsAndUses(rand.Int(), rand.Uint32(), true)
 	assert.Empty(t, cau.Create())
 	assert.Empty(t, cau.Delete())
 
-	cau = NewChannelsAndUses(6464333, 79797, true)
+	cau = NewChannelsAndUses(rand.Int(), rand.Uint32(), true)
 	assert.Empty(t, cau.Create())
 	cau.IsAdmin = false
 	assert.Empty(t, cau.Delete())
 	assert.Equal(t, false, IsExistCAUByChannelIdAndUserId(cau.ChannelId, cau.UserId))
 
-	channelId := 37597692793
-	userId := uint32(35362622)
+	channelId := rand.Int()
+	userId := rand.Uint32()
 	cau = NewChannelsAndUses(channelId, userId, true)
 	assert.Empty(t, cau.Create())
 	assert.Equal(t, true, IsExistCAUByChannelIdAndUserId(channelId, userId))
@@ -110,10 +110,10 @@ func TestDeleteCAUByChannelId(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	channelId := 525325
+	channelId := rand.Int()
 	userIds := make([]uint32, 20)
 	for i := 0; i < 20; i++ {
-		userIds[i] = uint32(758932 + i*10)
+		userIds[i] = rand.Uint32()
 	}
 
 	for _, userId := range userIds {

--- a/backend/models/channels_test.go
+++ b/backend/models/channels_test.go
@@ -2,21 +2,21 @@ package models
 
 import (
 	"math/rand"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xyproto/randomstring"
 )
 
 func TestCreateChannel(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	name := "testCreateChannelModelName"
-	description := "testCreateChannelModelDescription"
+	name := randomstring.EnglishFrequencyString(30)
+	description := randomstring.EnglishFrequencyString(30)
 	is_private := true
 	is_archive := false
-	workspaceId := 7397593
+	workspaceId := rand.Int()
 	c := NewChannel(0, name, description, is_private, is_archive, workspaceId)
 	assert.Empty(t, c.Create())
 }
@@ -25,11 +25,11 @@ func TestGetChannelById(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	name := "testGetChannelByIdName"
-	description := "testGetChannelByIdDescription"
+	name := randomstring.EnglishFrequencyString(30)
+	description := randomstring.EnglishFrequencyString(30)
 	is_private := true
 	is_archive := false
-	workspaceId := 3999526
+	workspaceId := rand.Int()
 	c := NewChannel(0, name, description, is_private, is_archive, workspaceId)
 	assert.Empty(t, c.Create())
 	assert.NotEqual(t, 0, c.ID)
@@ -45,7 +45,7 @@ func TestDeleteChannel(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	c := NewChannel(0, "testDeleteChannelName", "", true, false, 58430850380)
+	c := NewChannel(0, randomstring.EnglishFrequencyString(30), "", true, false, rand.Int())
 	assert.Empty(t, c.Create())
 	channelId := c.ID
 	assert.Empty(t, c.Delete())
@@ -63,12 +63,11 @@ func TestGetChannelsByWorkspaceId(t *testing.T) {
 	// 2. データが存在しない場合
 
 	t.Run("1 データが存在する場合", func(t *testing.T) {
-		testNum := "1"
 		channelCount := 10
 		workspaceId := int(rand.Uint64())
 		channels := make([]Channel, channelCount)
 		for i := 0; i < channelCount; i++ {
-			channelName := "testGetChannelsByWorkspaceId" + testNum + "." + strconv.Itoa(i)
+			channelName := randomstring.EnglishFrequencyString(30)
 			ch := NewChannel(0, channelName, "des", false, false, workspaceId)
 			assert.Empty(t, ch.Create())
 			channels[i] = *ch

--- a/backend/models/messages_test.go
+++ b/backend/models/messages_test.go
@@ -1,9 +1,11 @@
 package models
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xyproto/randomstring"
 
 	"backend/utils"
 )
@@ -12,9 +14,9 @@ func TestCreateMessage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	text := "test message"
-	channelId := 7675071751
-	userId := uint32(3571521121)
+	text := randomstring.EnglishFrequencyString(30)
+	channelId := rand.Int()
+	userId := rand.Uint32()
 	m := NewMessage(text, channelId, userId)
 	assert.Empty(t, m.Create())
 	assert.NotEqual(t, 0, m.ID)
@@ -34,10 +36,10 @@ func TestGetMessagesByChannelId(t *testing.T) {
 		testNum := 100
 		texts := make([]string, testNum)
 		for i := 0; i < testNum; i++ {
-			texts[i] = "testGetMessagesByChannelId"
+			texts[i] = randomstring.EnglishFrequencyString(30)
 		}
-		channelId := 37590793729
-		userId := uint32(536357900)
+		channelId := rand.Int()
+		userId := rand.Uint32()
 
 		for _, text := range texts {
 			m := NewMessage(text, channelId, userId)
@@ -57,7 +59,7 @@ func TestGetMessagesByChannelId(t *testing.T) {
 		for _, m := range messages {
 			assert.Equal(t, channelId, m.ChannelId)
 			assert.Equal(t, userId, m.UserId)
-			assert.Equal(t, texts[0], m.Text)
+			assert.Contains(t, texts, m.Text)
 		}
 	})
 

--- a/backend/models/user_test.go
+++ b/backend/models/user_test.go
@@ -2,10 +2,10 @@ package models
 
 import (
 	"math/rand"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xyproto/randomstring"
 )
 
 func CreateTest(t *testing.T) {
@@ -14,7 +14,7 @@ func CreateTest(t *testing.T) {
 	}
 	t.Run("1", func(t *testing.T) {
 		for i := 0; i < 10; i++ {
-			u := NewUser(rand.Uint32(), "createModelUserTest1"+strconv.Itoa(i), "pass")
+			u := NewUser(rand.Uint32(), randomstring.EnglishFrequencyString(30), "pass")
 			assert.Empty(t, u.Create())
 		}
 	})
@@ -28,7 +28,7 @@ func GetUserByNameAndPasswordTest(t *testing.T) {
 		password := "pass"
 		for i := 0; i < 10; i++ {
 			id := rand.Uint32()
-			name := "loginModelUserTest1" + strconv.Itoa(i)
+			name := randomstring.EnglishFrequencyString(30)
 			u := NewUser(id, name, password)
 			assert.Empty(t, u.Create())
 			u1, err := GetUserByNameAndPassword(name, password)

--- a/backend/models/workspace_and_users_test.go
+++ b/backend/models/workspace_and_users_test.go
@@ -12,11 +12,11 @@ func TestNewWorkspaceAndUsers(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 	for i := 0; i < 10; i++ {
-		workspaceId := i + 1
-		for j := 0; j < 100; j++ {
-			userId := uint32(j + 1)
+		workspaceId := rand.Int()
+		for j := 0; j < 10; j++ {
+			userId := rand.Uint32()
 			roleId := j%4 + 1
-			wau := NewWorkspaceAndUsers(workspaceId, uint32(userId), roleId)
+			wau := NewWorkspaceAndUsers(workspaceId, userId, roleId)
 			assert.Equal(t, workspaceId, wau.WorkspaceId)
 			assert.Equal(t, userId, wau.UserId)
 			assert.Equal(t, roleId, wau.RoleId)
@@ -29,14 +29,14 @@ func TestCreate(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 	for i := 0; i < 10; i++ {
-		workspaceId := i + 1
-		for j := 0; j < 100; j++ {
-			userId := uint32(j + 1)
+		workspaceId := rand.Int()
+		for j := 0; j < 10; j++ {
+			userId := rand.Uint32()
 			roleId := j%4 + 1
-			wau := NewWorkspaceAndUsers(workspaceId, uint32(userId), roleId)
+			wau := NewWorkspaceAndUsers(workspaceId, userId, roleId)
 			assert.Empty(t, wau.Create())
 			assert.NotEmpty(t, wau.Create())
-			wau = NewWorkspaceAndUsers(workspaceId, uint32(userId), (roleId+1)%4)
+			wau = NewWorkspaceAndUsers(workspaceId, userId, (roleId+1)%4)
 			assert.NotEmpty(t, wau.Create())
 		}
 	}
@@ -47,9 +47,9 @@ func TestGetWorkspaceAndUserByWorkspaceIdAndUserId(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 	for i := 0; i < 10; i++ {
-		workspaceId := i + 1 + 100
-		for j := 0; j < 100; j++ {
-			userId := uint32(j + 1)
+		workspaceId := rand.Int()
+		for j := 0; j < 10; j++ {
+			userId := rand.Uint32()
 			roleId := j%4 + 1
 			wau := NewWorkspaceAndUsers(workspaceId, userId, roleId)
 			wau.Create()
@@ -59,7 +59,7 @@ func TestGetWorkspaceAndUserByWorkspaceIdAndUserId(t *testing.T) {
 			assert.Equal(t, userId, getWau.UserId)
 			assert.Equal(t, roleId, getWau.RoleId)
 
-			_, err = GetWorkspaceAndUserByWorkspaceIdAndUserId(workspaceId+1000, userId)
+			_, err = GetWorkspaceAndUserByWorkspaceIdAndUserId(rand.Int(), userId)
 			assert.NotEmpty(t, err)
 		}
 	}
@@ -70,9 +70,9 @@ func TestDeleteWorkspaceAndUser(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 	for i := 0; i < 10; i++ {
-		workspaceId := i + 200
-		for j := 0; j < 100; j++ {
-			userId := uint32(j + 2)
+		workspaceId := rand.Int()
+		for j := 0; j < 10; j++ {
+			userId := rand.Uint32()
 			roleId := j%4 + 1
 			wau := NewWorkspaceAndUsers(workspaceId, userId, roleId)
 			assert.Empty(t, wau.Create())
@@ -92,13 +92,13 @@ func TestGetRoleIdByWorkspaceIdAndUserId(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	wau := NewWorkspaceAndUsers(37598379769, uint32(793457957), 3)
+	wau := NewWorkspaceAndUsers(rand.Int(), rand.Uint32(), 3)
 	wau.Create()
 	roleId, err := GetRoleIdByWorkspaceIdAndUserId(wau.WorkspaceId, wau.UserId)
 	assert.Equal(t, wau.RoleId, roleId)
 	assert.Empty(t, err)
 
-	_, err = GetRoleIdByWorkspaceIdAndUserId(-1, wau.UserId)
+	_, err = GetRoleIdByWorkspaceIdAndUserId(rand.Int(), wau.UserId)
 	assert.NotEmpty(t, err)
 }
 

--- a/backend/models/workspace_test.go
+++ b/backend/models/workspace_test.go
@@ -2,10 +2,11 @@ package models
 
 import (
 	"fmt"
-	"strconv"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xyproto/randomstring"
 
 	"backend/config"
 )
@@ -14,10 +15,10 @@ func TestNewWorkspace(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	for i := 0; i < 1000; i++ {
-		id := i
-		name := "testNewWorkspaceName" + strconv.Itoa(i)
-		primary_owner_id := uint32(i) + 10
+	for i := 0; i < 10; i++ {
+		id := rand.Int()
+		name := randomstring.EnglishFrequencyString(30)
+		primary_owner_id := rand.Uint32()
 		w := NewWorkspace(id, name, primary_owner_id)
 		assert.Equal(t, id, w.ID)
 		assert.Equal(t, name, w.Name)
@@ -34,8 +35,8 @@ func TestCreateWorkspace(t *testing.T) {
 	names := make([]string, numbersOfTests)
 	primaryOwnerIds := make([]uint32, numbersOfTests)
 	for i := 0; i < numbersOfTests; i++ {
-		names[i] = "testCreateWorkspace" + strconv.Itoa(i)
-		primaryOwnerIds[i] = uint32(i) + 11
+		names[i] = randomstring.EnglishFrequencyString(30)
+		primaryOwnerIds[i] = rand.Uint32()
 	}
 
 	for i := 0; i < numbersOfTests; i++ {
@@ -56,11 +57,11 @@ func TestCreateWorkspace(t *testing.T) {
 	}
 
 	// workspace nameが既に存在する場合 error
-	name := "testCreateWorkspaceDuplicate"
-	w := NewWorkspace(0, name, uint32(2))
+	name := randomstring.EnglishFrequencyString(30)
+	w := NewWorkspace(0, name, rand.Uint32())
 	err := w.Create()
 	assert.Empty(t, err)
-	w2 := NewWorkspace(0, name, uint32(1))
+	w2 := NewWorkspace(0, name, rand.Uint32())
 	err = w2.Create()
 	assert.NotEmpty(t, err)
 }
@@ -69,9 +70,9 @@ func TestRenameWorkspaceName(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	w := NewWorkspace(3333, "old name", 3)
+	w := NewWorkspace(rand.Int(), randomstring.EnglishFrequencyString(30), 3)
 	w.Create()
-	w.Name = "new name"
+	w.Name = randomstring.EnglishFrequencyString(30)
 	err := w.RenameWorkspaceName()
 	assert.Empty(t, err)
 	w2, err := GetWorkspaceById(w.ID)


### PR DESCRIPTION
テストで使うデータをすべてランダム生成することで、テストの度にデータベースを消す必要がなくなった。