### PR TITLE
TokenがセットされていないときにgetTokenが呼ばれないようにする（ログイン状態確認）

### DIFF
--- a/frontend/pages/component/workspace_index.tsx
+++ b/frontend/pages/component/workspace_index.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 import { getWorkspaces, Workspace } from 'pages/fetchAPI/workspace'
-import { getToken } from "@/pages/fetchAPI/cookie";
 
 function WorkspaceIndex() {
   const [workspaceList, setWorkspaceList] = useState<Workspace[]>([]);
 
-  const list = workspaceList.map((item, index) => (
+  const list = Object.values(workspaceList).map((item, index) => (
     <div key={index}>
       <p>{item.id}</p>
       <p>{item.name}</p>
@@ -13,14 +12,12 @@ function WorkspaceIndex() {
     </div>
   ));
   const handleGetWorkspaces = () => {
-    if (typeof getToken() !== 'undefined') {
-      getWorkspaces().then((workspaces: Workspace[]) => {
-        console.log("workspaces")
-        console.log(workspaces)
-        setWorkspaceList(workspaces)
-        console.log(workspaceList)
-      });
-    }
+    getWorkspaces().then((workspaces: Workspace[]) => {
+      console.log("workspaces")
+      console.log(workspaces)
+      setWorkspaceList(workspaces)
+      console.log(workspaceList)
+    });
   }
 
   return (

--- a/frontend/pages/component/workspace_index.tsx
+++ b/frontend/pages/component/workspace_index.tsx
@@ -1,33 +1,35 @@
 import React, { useState } from "react";
-import { getWorkspaces, Workspace } from 'pages/fetchAPI/workspace'
+import { getWorkspaces, Workspace } from 'pages/fetchAPI/workspace';
 
 function WorkspaceIndex() {
   const [workspaceList, setWorkspaceList] = useState<Workspace[]>([]);
-
-  const list = Object.values(workspaceList).map((item, index) => (
+  const list = workspaceList.map((item, index) => (
     <div key={index}>
       <p>{item.id}</p>
       <p>{item.name}</p>
       <p>{item.primary_owner_id}</p>
     </div>
   ));
+  
   const handleGetWorkspaces = () => {
-    getWorkspaces().then((workspaces: Workspace[]) => {
-      console.log("workspaces")
-      console.log(workspaces)
-      setWorkspaceList(workspaces)
-      console.log(workspaceList)
-    });
+        getWorkspaces().then((workspaces: Workspace[]) => {
+        console.log("workspaces")
+          console.log(workspaces)
+          if (Array.isArray(workspaces)) {
+            setWorkspaceList(workspaces)
+          }
+        console.log(workspaceList)
+      });
   }
-
-  return (
-    <div className="App">
-      <button onClick={handleGetWorkspaces}>ワークスペース一覧を表示</button>
-      <div>
-        {list}
+  
+    return (
+      <div className="App">
+        <button onClick={handleGetWorkspaces}>ワークスペース一覧を表示</button>
+        <div>
+          {list}
+        </div>
       </div>
-    </div>
-  );
+    );
 }
 
 export default WorkspaceIndex;


### PR DESCRIPTION
- cookieに値をセットする処理と、セットした値を取り出す処理は、それぞれ分けてWebサーバとの間でやりとりをする必要があった。それぞれイベントを分けることで解決できる。
[HTTP Cookie](https://www.infraexpert.com/study/tcpip16.6.html)

- cookieがセットされていないときにworkspace一覧を取得しようとするとエラーが出ていたが、原因は
objectにmapを使ってリストにしようとしていたことだった。
返ってきたエラーメッセージ（以下のobject）がworkspaceListに格納されていた
![image](https://user-images.githubusercontent.com/65808164/223999691-8bec694e-2971-4f25-8df9-ef15d2bcb387.png)

→　配列が返ってきた場合にworkspaceListにセットするようにする
`getWorkspaces().then((workspaces: Workspace[]) => {
          if (Array.isArray(workspaces)) {
            setWorkspaceList(workspaces)
          }        
      });`


~~objectにmapを使っていたのを修正。~~

~~`const list = workspaceList.map((item, index) => (
    <div key={index}>
      ...
    </div>
  ));`~~

~~修正後~~
~~`const list = Object.values(workspaceList).map((item, index) => (
    <div key={index}>
      ...
    </div>
  ));`~~
