### PR TITLE
create channelのpopupを作成

### DIFF
--- a/frontend/src/components/popUp/create_channel.tsx
+++ b/frontend/src/components/popUp/create_channel.tsx
@@ -1,77 +1,79 @@
-import { getToken } from "@fetchAPI/cookie";
+import { postChannel } from "@src/fetchAPI/channel";
+import React, { useState } from "react";
+import { useParams } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
 
-export interface Channel {
-  id: number;
-  name: string;
-  description: string;
-  is_private: boolean;
-  is_archive: boolean;
-  workspace_id: number;
-}
+const CreatChannelForm = () => {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [isPrivate, setIsPrivate] = useState(false);
+  const { workspaceId } = useParams<{ workspaceId: string }>();
 
-export interface CurrentChannel {
-  name: string;
-  description: string;
-  is_private: boolean;
-  workspace_id: number;
-}
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
+  };
 
-const baseUrl = "http://localhost:8080/api/channel/";
+  const nameChange = (e: any) => {
+    setName(e.target.value);
+  };
 
-export async function getChannelsByWorkspaceId(
-  workspace_id: number
-): Promise<Channel[]> {
-  const url = baseUrl + "get_by_user_and_workspace/" + workspace_id;
-  console.log(url);
-  // let res_channels: Channel[]
-  let res_channels = [
-    {
-      id: 0,
-      name: "",
-      description: "",
-      is_private: false,
-      is_archive: false,
-      workspace_id: 0,
-    },
-  ];
-  try {
-    const res = await fetch(url, {
-      method: "GET",
-      headers: {
-        Authorization: getToken(),
-      },
-    });
-    console.log(res);
-    res_channels = await res.json();
-    return new Promise((resolve) => {
-      resolve(res_channels);
-    });
-  } catch (err) {
-    console.log("err");
-    console.log(err);
-  }
-  return res_channels;
-}
+  const isPrivateChangeTrue = () => {
+    setIsPrivate(true);
+  };
+  const isPrivateChangeFalse = () => {
+    setIsPrivate(false);
+  };
 
-export async function postChannel(current: CurrentChannel) {
-  const url = baseUrl + "create";
-  let channel: Channel;
-  try {
-    const res = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: getToken(),
-      },
-      body: JSON.stringify({
-        name: current.name,
-        description: current.description,
-        is_private: current.is_private,
-        workspace_id: current.workspace_id,
-      }),
-    });
-    channel = await res.json();
-  } catch (err) {
-    console.log(err);
-  }
-  return;
-}
+
+  const handleSubmit = () => {
+    console.log("create channel");
+    let channel = { name: name, description: description, is_private: isPrivate, workspace_id: parseInt(workspaceId) };
+    postChannel(channel);
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <div>
+        <Button onClick={handleClickOpen}>
+          <p style={{ color: 'black'}}>新しいチャンネルを作成</p>
+        </Button>
+      </div>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>Create a channel</DialogTitle>
+        <DialogContent>
+          <label htmlFor="name">
+            名前<br />
+            <input type="text" value={name} name="name" onChange={nameChange} />
+          </label>
+
+          <fieldset>
+            <legend>可視性</legend>
+            <label htmlFor="is_private">
+              <input type="radio" name="isPrivate" onChange={isPrivateChangeTrue} />
+              プライベート : 特定のメンバーのみ
+            </label><br />
+            <label htmlFor="is_private">
+              <input type="radio" name="isPrivate" onChange={isPrivateChangeFalse} checked/>
+              パブリック : Slack 内の全員
+            </label>
+          </fieldset> 
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={handleClose}>閉じる</Button>
+          <Button variant="contained" color="success" onClick={handleSubmit}>作成</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default CreatChannelForm;

--- a/frontend/src/components/popUp/create_channel.tsx
+++ b/frontend/src/components/popUp/create_channel.tsx
@@ -7,7 +7,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 
-const CreatChannelForm = () => {
+const CreateChannelForm = () => {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -76,4 +76,4 @@ const CreatChannelForm = () => {
   );
 };
 
-export default CreatChannelForm;
+export default CreateChannelForm;

--- a/frontend/src/components/sideNav2/show_channels/[id].tsx
+++ b/frontend/src/components/sideNav2/show_channels/[id].tsx
@@ -1,13 +1,25 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link } from 'react-router-dom';
 import { MenuItem, SubMenu } from "react-pro-sidebar";
 import { getChannelsByWorkspaceId, Channel } from '@fetchAPI/channel';
 import { useParams } from "react-router-dom";
+import CreatChannelForm from "@src/components/popUp/create_channel";
+import Button from "@mui/material/Button";
+import Popover from "@mui/material/Popover";
 
 
 function ChannelIndex() {
+  const [open, setOpen] = useState(false);
   const [channelList, setChannelList] = useState<Channel[]>([]);
   const { workspaceId } = useParams<{ workspaceId: string }>();
+  const divRef = useRef(null);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
+  };
 
   const list = channelList.map((item, index) => (
     <div key={index}>
@@ -35,6 +47,24 @@ function ChannelIndex() {
     <div>
       <SubMenu label="Channels">
         {list}
+        <div ref={divRef} style={{ backgroundColor: "rgb(63, 14, 64)" }}>
+          <Button onClick={handleClickOpen}>
+          <p style={{ color: 'rgb(153, 133, 156)'}}>+ チャンネルを追加</p>
+          </Button>
+          <Popover
+              open={open}
+              anchorEl={divRef.current}
+              onClose={handleClose}
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'left',
+              }}
+            >
+            < CreatChannelForm />
+            <Button><p style={{ color: 'black'}}>チャンネル一覧</p></Button>
+            {/* チャンネル一覧ページへの移動ボタンを設置する（未） */}
+          </Popover>
+        </div>
       </SubMenu>
       
     </div>

--- a/frontend/src/components/sideNav2/show_channels/[id].tsx
+++ b/frontend/src/components/sideNav2/show_channels/[id].tsx
@@ -3,9 +3,9 @@ import { Link } from 'react-router-dom';
 import { MenuItem, SubMenu } from "react-pro-sidebar";
 import { getChannelsByWorkspaceId, Channel } from '@fetchAPI/channel';
 import { useParams } from "react-router-dom";
-import CreatChannelForm from "@src/components/popUp/create_channel";
 import Button from "@mui/material/Button";
 import Popover from "@mui/material/Popover";
+import CreateChannelForm from "@src/components/popUp/create_channel";
 
 
 function ChannelIndex() {
@@ -60,7 +60,7 @@ function ChannelIndex() {
                 horizontal: 'left',
               }}
             >
-            < CreatChannelForm />
+            < CreateChannelForm />
             <Button><p style={{ color: 'black'}}>チャンネル一覧</p></Button>
             {/* チャンネル一覧ページへの移動ボタンを設置する（未） */}
           </Popover>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65808164/236593586-0cbe3a88-9bcc-4e21-98d4-153d25c71f4e.png)

### popover
![image](https://user-images.githubusercontent.com/65808164/236593607-6de1c082-f951-4f7b-a818-f566427e51ed.png)
https://mui.com/material-ui/react-popover/

### dialog
![image](https://user-images.githubusercontent.com/65808164/236593536-138b0728-57d2-4988-9d29-e26c656dff07.png)
https://mui.com/material-ui/react-dialog/

descriptionは記入せずにチャンネルを作成する形にしています（空白で登録される）
理由はslackのアプリの仕様に合わせたためです
チャンネル作成後に説明を追加できる形になっているようです（未実装）