### PR TITLE
196 frontend refactoring

### DIFF
--- a/frontend/src/components/main/user.tsx
+++ b/frontend/src/components/main/user.tsx
@@ -4,12 +4,17 @@ import { currentUser, login } from '@fetchAPI/login'
 import { resetCookie } from "@src/fetchAPI/cookie";
 import router from "next/router";
 import Button from "@mui/material/Button";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import { getWorkspaces, Workspace} from '@fetchAPI/workspace'
+import { workspacesState } from "@src/utils/atom";
 
 const LoginForm = () => {
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
-  const [cookies, setCookie, removeCookie] = useCookies(['token','user_id']);
+  const [cookies, setCookie, removeCookie] = useCookies(['token', 'user_id']);
+  const setWorkspaces = useSetRecoilState(workspacesState);
+  const navigate = useNavigate();
 
   const nameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);
@@ -25,6 +30,10 @@ const LoginForm = () => {
       if (currentUser.token) {
         setCookie("token", currentUser.token);
         setCookie("user_id", currentUser.user_id);
+        getWorkspaces().then((workspaces: Workspace[]) => {
+          setWorkspaces(workspaces);
+          navigate("workspace");
+        });
       }
     });
   };

--- a/frontend/src/components/sideNav1/show_workspaces.tsx
+++ b/frontend/src/components/sideNav1/show_workspaces.tsx
@@ -1,28 +1,26 @@
-import React, { useEffect, useState } from "react";
-import { getWorkspaces, Workspace, UserInWorkspace, getUsersInWorkspace} from '@fetchAPI/workspace'
+import React from "react";
+import { UserInWorkspace, getUsersInWorkspace} from '@fetchAPI/workspace'
 import { Link } from 'react-router-dom';
 import { MenuItem } from "react-pro-sidebar";
-import { atom, useRecoilState } from "recoil";
-
-export const usersInWState = atom<UserInWorkspace[]>({
-  key: "usersInW",
-  default: []
-})
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { channelsState, usersInWState, workspacesState } from "@src/utils/atom";
+import { Channel, getChannelsByWorkspaceId } from "@src/fetchAPI/channel";
 
 function ShowWorkspaces() {
-
-  const [usersInW, setUsersInW] = useRecoilState(usersInWState);
-
-  const [workspaceList, setWorkspaceList] = useState<Workspace[]>([]);
-  
+  const setUsersInW = useSetRecoilState(usersInWState);
+  const setChannels = useSetRecoilState(channelsState);
+  const workspaces = useRecoilValue(workspacesState);
   const getWorkspaceInfo = (workspaceId: number) =>{
     getUsersInWorkspace(workspaceId).then(
       (usersInW: UserInWorkspace[]) => {
-      setUsersInW(usersInW);
-    });
+        setUsersInW(usersInW);
+      });
+    getChannelsByWorkspaceId(workspaceId).then(
+      (channels: Channel[]) => {
+        setChannels(channels);
+      });
   }
-
-  const list = workspaceList.map((workspace, index) => (
+  const list = workspaces.map((workspace, index) => (
     <div key={index}>
       <MenuItem>
         <Link to={`${workspace.id}`} onClick={() => getWorkspaceInfo(workspace.id)}>
@@ -31,12 +29,6 @@ function ShowWorkspaces() {
       </ MenuItem>
     </div>
   ));
-
-  useEffect(() => {
-    getWorkspaces().then((workspaces: Workspace[]) => {
-      setWorkspaceList(workspaces);
-    });
-  },[]);
 
   return (
     <div className="App">

--- a/frontend/src/components/sideNav2/show_channels/[id].tsx
+++ b/frontend/src/components/sideNav2/show_channels/[id].tsx
@@ -1,21 +1,16 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { Link } from 'react-router-dom';
 import { MenuItem, SubMenu } from "react-pro-sidebar";
-import { getChannelsByWorkspaceId, Channel } from '@fetchAPI/channel';
-import { useParams } from "react-router-dom";
-
 import Button from "@mui/material/Button";
 import Popover from "@mui/material/Popover";
 import CreateChannelForm from "@src/components/popUp/create_channel";
-
-
+import { useRecoilValue } from "recoil";
+import { channelsState } from "@src/utils/atom";
 
 function ShowChannels() {
-
   const [open, setOpen] = useState(false);
-  const [channelList, setChannelList] = useState<Channel[]>([]);
-  const { workspaceId } = useParams<{ workspaceId: string }>();
   const divRef = useRef(null);
+  const channels = useRecoilValue(channelsState);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -24,7 +19,7 @@ function ShowChannels() {
     setOpen(false);
   };
 
-  const list = channelList.map((item, index) => (
+  const list = channels.map((item, index) => (
     <div key={index}>
       <MenuItem className="bg-purple-200 text-pink-700">
         <Link to="tmp_main">
@@ -33,12 +28,6 @@ function ShowChannels() {
       </MenuItem>
     </div>
   ));
-
-  useEffect(() => {
-    getChannelsByWorkspaceId(Number(workspaceId)).then((channels: Channel[]) => {
-      setChannelList(channels)
-    });
-  },[workspaceId])
 
   return (
     <div>

--- a/frontend/src/pages/main/login_form.tsx
+++ b/frontend/src/pages/main/login_form.tsx
@@ -2,15 +2,26 @@ import React, { useEffect } from "react";
 import { useCookies } from "react-cookie";
 import { LoginForm } from "@src/components/main/user";
 import { useNavigate } from 'react-router-dom';
+import { Workspace, getWorkspaces } from "@src/fetchAPI/workspace";
+import { useSetRecoilState } from "recoil";
+import { workspacesState } from "@src/utils/atom";
+
 
 function Login() {
   const [cookies, setCookie, removeCookie] = useCookies(['token', 'user_id']);
+  const setWorkspaces = useSetRecoilState(workspacesState);
   const navigate = useNavigate();
-  useEffect(() => {
+
+  // useEffect削除（未）
+  useEffect(()=>{
     if (cookies.token) {
-      navigate("workspace");
+      getWorkspaces().then((workspaces: Workspace[]) => {
+        setWorkspaces(workspaces);
+        navigate("workspace");
+      });
     }
-  },[cookies.token])
+  }, [cookies.token])
+  
   return (
     <div>
       < LoginForm />
@@ -19,3 +30,5 @@ function Login() {
 }
 
 export default Login;
+
+

--- a/frontend/src/pages/route.tsx
+++ b/frontend/src/pages/route.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { HashRouter, BrowserRouter, Route, Routes } from 'react-router-dom';
 import Login from './main/login_form';
 import SignUp from './main/signUp_form';
 import SideNav2 from './sideNav2';
@@ -12,7 +12,7 @@ import { RecoilRoot } from 'recoil';
 export const RouterConfig: React.FC = () => {
   return (
     <RecoilRoot>
-     <BrowserRouter>
+     <HashRouter>
         <Routes >
           <Route path="/">
             <Route index element={<Login />} />
@@ -26,7 +26,7 @@ export const RouterConfig: React.FC = () => {
             </Route>
           </Route>
         </Routes>
-      </BrowserRouter>
+      </HashRouter>
     </RecoilRoot>
   );
 }

--- a/frontend/src/utils/atom.ts
+++ b/frontend/src/utils/atom.ts
@@ -1,0 +1,18 @@
+import { Channel } from "@src/fetchAPI/channel";
+import { UserInWorkspace, Workspace } from "@src/fetchAPI/workspace";
+import { atom } from "recoil";
+
+export const workspacesState = atom<Workspace[]>({
+  key: "workspaces",
+  default: []
+})
+
+export const channelsState = atom<Channel[]>({
+  key: "channels",
+  default: []
+})
+
+export const usersInWState = atom<UserInWorkspace[]>({
+  key: "usersInW",
+  default: []
+})


### PR DESCRIPTION
- useEffectの削除
  （ログインページに移動したときに、トークンがセットされているか確認する（重複ログインを防ぐ）ためのuseEffectはまだ残っています。別のプルリクで修正?）
- チャンネルリスト、ワークスペースリスト、ワークスペースのユーザーリストをatomに保存

- ~BrowserRouterをHashRouterに変更（リロードをすると404になるため）~