### PR TITLE
予約機能を作成

### DIFF
--- a/backend/controllerUtils/check_existing_test.go
+++ b/backend/controllerUtils/check_existing_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/xyproto/randomstring"
 
 	"backend/models"
+	"backend/utils"
 )
 
 func TestIsExistCAUByChannelIdAndUserId(t *testing.T) {
@@ -84,7 +85,7 @@ func TestIsExistMessageById(t *testing.T) {
 	}
 
 	t.Run("1 データが存在する場合", func(t *testing.T) {
-		m := models.NewChannelMessage(randomstring.EnglishFrequencyString(100), int(rand.Uint32()), rand.Uint32())
+		m := models.NewChannelMessage(randomstring.EnglishFrequencyString(100), int(rand.Uint32()), rand.Uint32(), utils.CreateDefaultTime())
 		assert.Empty(t, m.Create(db))
 		b, err := IsExistMessageById(m.ID)
 		assert.Empty(t, err)

--- a/backend/controllerUtils/input.go
+++ b/backend/controllerUtils/input.go
@@ -2,6 +2,7 @@ package controllerUtils
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -45,9 +46,10 @@ type AddUserInChannelInput struct {
 }
 
 type SendMessageInput struct {
-	Text             string   `json:"text"`
-	ChannelId        int      `json:"channel_id"`
-	MentionedUserIDs []uint32 `json:"mentioned_user_ids"`
+	Text             string    `json:"text"`
+	ChannelId        int       `json:"channel_id"`
+	MentionedUserIDs []uint32  `json:"mentioned_user_ids"`
+	ScheduleTime     time.Time `json:"schedule_time"`
 }
 
 type EditMessageInput struct {
@@ -55,10 +57,11 @@ type EditMessageInput struct {
 }
 
 type SendDMInput struct {
-	ReceiveUserId    uint32   `json:"received_user_id"`
-	Text             string   `json:"text"`
-	WorkspaceId      int      `json:"workspace_id"`
-	MentionedUserIDs []uint32 `json:"mentioned_user_ids"`
+	ReceiveUserId    uint32    `json:"received_user_id"`
+	Text             string    `json:"text"`
+	WorkspaceId      int       `json:"workspace_id"`
+	MentionedUserIDs []uint32  `json:"mentioned_user_ids"`
+	ScheduleTime     time.Time `json:"schedule_time"`
 }
 
 type EditDMInput struct {

--- a/backend/controllerUtils/response_data.go
+++ b/backend/controllerUtils/response_data.go
@@ -1,0 +1,34 @@
+package controllerUtils
+
+import (
+	"sort"
+	"time"
+
+	"backend/models"
+)
+
+func FilterByFutureScheduleTimeOfMessages(messages []models.Message) []models.Message {
+	result := make([]models.Message, 0)
+	nowDate := time.Now()
+	for _, m := range messages {
+		if m.ScheduleTime.After(nowDate) {
+			continue
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func UpdateCreatedAt(messages []models.Message) []models.Message {
+	for i, m := range messages {
+		if m.ScheduleTime.After(m.CreatedAt) {
+			messages[i].CreatedAt = m.ScheduleTime
+		}
+	}
+	return messages
+}
+
+func SortMessageByCreatedAt(messages []models.Message) []models.Message {
+	sort.Slice(messages, func(i, j int) bool { return messages[i].CreatedAt.After(messages[j].CreatedAt) })
+	return messages
+}

--- a/backend/controllers/setup.go
+++ b/backend/controllers/setup.go
@@ -71,7 +71,7 @@ func SetupRouter1() *gin.Engine {
 	return r
 }
 
-func SetupRouter2() *gin.Engine{
+func SetupRouter2() *gin.Engine {
 	r := settingRouter()
 	r.GET("/", func(ctx *gin.Context) {
 		ctx.JSON(http.StatusOK, gin.H{"message": "server2 OK"})

--- a/backend/controllers/test_func.go
+++ b/backend/controllers/test_func.go
@@ -7,10 +7,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"time"
 
+	"backend/controllerUtils"
 	"backend/models"
 	"backend/utils"
-	"backend/controllerUtils"
 )
 
 var testRouter = SetupRouter1()
@@ -104,11 +105,12 @@ func addUserInChannelTestFuncV2(channelID int, userID uint32, jwtToken string) (
 	return rr, cau
 }
 
-func sendMessageTestFuncV2(text string, channelID int, jwtToken string, mentionedUserIDs []uint32) (*httptest.ResponseRecorder, models.Message) {
+func sendMessageTestFuncV2(text string, channelID int, jwtToken string, mentionedUserIDs []uint32, scheduleTime time.Time) (*httptest.ResponseRecorder, models.Message) {
 	rr := Req(http.MethodPost, "/api/message/send", jwtToken, controllerUtils.SendMessageInput{
 		Text:             text,
 		ChannelId:        channelID,
 		MentionedUserIDs: mentionedUserIDs,
+		ScheduleTime:     scheduleTime,
 	})
 	byteArray, _ := io.ReadAll(rr.Body)
 	var m models.Message
@@ -116,12 +118,13 @@ func sendMessageTestFuncV2(text string, channelID int, jwtToken string, mentione
 	return rr, m
 }
 
-func sendDMTestFuncV2(text string, jwtToken string, receiveUserID uint32, workspaceID int, mentionedUserIDs []uint32) (*httptest.ResponseRecorder, models.Message) {
+func sendDMTestFuncV2(text string, jwtToken string, receiveUserID uint32, workspaceID int, mentionedUserIDs []uint32, scheduleTime time.Time) (*httptest.ResponseRecorder, models.Message) {
 	rr := Req(http.MethodPost, "/api/dm/send", jwtToken, controllerUtils.SendDMInput{
 		Text:             text,
 		ReceiveUserId:    receiveUserID,
 		WorkspaceId:      workspaceID,
 		MentionedUserIDs: mentionedUserIDs,
+		ScheduleTime:     scheduleTime,
 	})
 	byteArray, _ := io.ReadAll(rr.Body)
 	var m models.Message
@@ -143,4 +146,20 @@ func getAllUsersInChannelTestFuncV2(channelID int, jwtToken string) (*httptest.R
 	var users []UserResponse
 	json.Unmarshal(([]byte)(byteArray), &users)
 	return rr, users
+}
+
+func getAllMessagesFromChannelTestFuncV2(channelID int, jwtToken string) (*httptest.ResponseRecorder, []models.Message) {
+	rr := Req(http.MethodGet, "/api/message/get_from_channel/"+strconv.Itoa(channelID), jwtToken, nil)
+	byteArray, _ := io.ReadAll(rr.Body)
+	var messages []models.Message
+	json.Unmarshal(([]byte)(byteArray), &messages)
+	return rr, messages
+}
+
+func getDMsInLineTestFuncV2(dmLineID uint, jwtToken string) (*httptest.ResponseRecorder, []models.Message) {
+	rr := Req(http.MethodGet, "/api/dm/"+utils.UintToString(dmLineID), jwtToken, nil)
+	byteArray, _ := io.ReadAll(rr.Body)
+	var messages []models.Message
+	json.Unmarshal(([]byte)(byteArray), &messages)
+	return rr, messages
 }

--- a/backend/controllers/threads.go
+++ b/backend/controllers/threads.go
@@ -8,6 +8,7 @@ import (
 
 	"backend/controllerUtils"
 	"backend/models"
+	"backend/utils"
 )
 
 func PostThread(c *gin.Context) {
@@ -78,7 +79,7 @@ func PostThread(c *gin.Context) {
 		}
 
 		// message structを作成
-		m = models.NewChannelMessage(in.Text, parentMessage.ChannelId, userId)
+		m = models.NewChannelMessage(in.Text, parentMessage.ChannelId, userId, utils.CreateDefaultTime())
 	} else if parentMessage.ChannelId == 0 && parentMessage.DMLineId != uint(0) {
 		// parentMessageが存在するDMLineにuserが参加しているかを確認
 		b, err := controllerUtils.IsExistUserInDL(userId, parentMessage.DMLineId)
@@ -94,7 +95,7 @@ func PostThread(c *gin.Context) {
 		}
 
 		// message structを作成
-		m = models.NewDMMessage(in.Text, parentMessage.DMLineId, userId)
+		m = models.NewDMMessage(in.Text, parentMessage.DMLineId, userId, utils.CreateDefaultTime())
 	} else {
 		tx.Rollback()
 		c.JSON(http.StatusInternalServerError, gin.H{"message": "wrong channel_id or dm_line_id"})

--- a/backend/models/messages.go
+++ b/backend/models/messages.go
@@ -5,34 +5,39 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+
+	"backend/utils"
 )
 
 type Message struct {
-	ID        uint      `json:"id" gorm:"primaryKey"`
-	Text      string    `json:"text" gorm:"not null"`
-	ChannelId int       `json:"channel_id"`
-	DMLineId  uint      `json:"dm_line_id" gorm:"column:dm_line_id"`
-	UserId    uint32    `json:"user_id" gorm:"not null"`
-	ThreadId  uint      `json:"thread_id"`
-	CreatedAt time.Time `json:"created_at" gorm:"not null"`
-	UpdatedAt time.Time `json:"updated_at" gorm:"not null"`
+	ID           uint      `json:"id" gorm:"primaryKey"`
+	Text         string    `json:"text" gorm:"not null"`
+	ChannelId    int       `json:"channel_id"`
+	DMLineId     uint      `json:"dm_line_id" gorm:"column:dm_line_id"`
+	UserId       uint32    `json:"user_id" gorm:"not null"`
+	ThreadId     uint      `json:"thread_id"`
+	ScheduleTime time.Time `json:"schedule_time"`
+	CreatedAt    time.Time `json:"created_at" gorm:"not null"`
+	UpdatedAt    time.Time `json:"updated_at" gorm:"not null"`
 }
 
-func NewChannelMessage(text string, channelId int, userId uint32) *Message {
+func NewChannelMessage(text string, channelId int, userId uint32, scheduleTime time.Time) *Message {
 	return &Message{
-		Text:      text,
-		ChannelId: channelId,
-		UserId:    userId,
-		DMLineId:  uint(0),
+		Text:         text,
+		ChannelId:    channelId,
+		UserId:       userId,
+		DMLineId:     uint(0),
+		ScheduleTime: scheduleTime,
 	}
 }
 
-func NewDMMessage(text string, dmLineId uint, userId uint32) *Message {
+func NewDMMessage(text string, dmLineId uint, userId uint32, scheduleTime time.Time) *Message {
 	return &Message{
-		Text:      text,
-		DMLineId:  dmLineId,
-		UserId:    userId,
-		ChannelId: 0,
+		Text:         text,
+		DMLineId:     dmLineId,
+		UserId:       userId,
+		ChannelId:    0,
+		ScheduleTime: scheduleTime,
 	}
 }
 
@@ -40,6 +45,7 @@ func (m *Message) Create(tx *gorm.DB) error {
 	if m.ChannelId != 0 && m.DMLineId != uint(0) {
 		return fmt.Errorf("channelId and dmLineId equal 0")
 	}
+	m.ScheduleTime = utils.GormTimeValidate(m.ScheduleTime)
 	return tx.Model(&Message{}).Create(m).Error
 }
 

--- a/backend/models/messages_test.go
+++ b/backend/models/messages_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/xyproto/randomstring"
 	"gorm.io/gorm"
+
+	"backend/utils"
 )
 
 func TestCreateMessage(t *testing.T) {
@@ -19,11 +21,11 @@ func TestCreateMessage(t *testing.T) {
 		text := randomstring.EnglishFrequencyString(30)
 		channelId := rand.Int()
 		userId := rand.Uint32()
-		m := NewChannelMessage(text, channelId, userId)
+		m := NewChannelMessage(text, channelId, userId, utils.CreateDefaultTime())
 		assert.Empty(t, m.Create(db))
 		assert.NotEqual(t, 0, m.ID)
 		assert.NotEqual(t, "", m.CreatedAt)
-		m = NewChannelMessage(text, channelId, userId)
+		m = NewChannelMessage(text, channelId, userId, utils.CreateDefaultTime())
 		assert.Empty(t, m.Create(db))
 		assert.NotEqual(t, 0, m.ID)
 		assert.NotEqual(t, "", m.CreatedAt)
@@ -33,11 +35,11 @@ func TestCreateMessage(t *testing.T) {
 		text := randomstring.EnglishFrequencyString(30)
 		dmLineId := uint(rand.Uint32())
 		userId := rand.Uint32()
-		m := NewDMMessage(text, dmLineId, userId)
+		m := NewDMMessage(text, dmLineId, userId, utils.CreateDefaultTime())
 		assert.Empty(t, m.Create(db))
 		assert.NotEqual(t, 0, m.ID)
 		assert.NotEqual(t, "", m.CreatedAt)
-		m = NewDMMessage(text, dmLineId, userId)
+		m = NewDMMessage(text, dmLineId, userId, utils.CreateDefaultTime())
 		assert.Empty(t, m.Create(db))
 		assert.NotEqual(t, 0, m.ID)
 		assert.NotEqual(t, "", m.CreatedAt)
@@ -59,7 +61,7 @@ func TestGetMessagesByChannelId(t *testing.T) {
 		userId := rand.Uint32()
 
 		for _, text := range texts {
-			m := NewChannelMessage(text, channelId, userId)
+			m := NewChannelMessage(text, channelId, userId, utils.CreateDefaultTime())
 			assert.Empty(t, m.Create(db))
 			time.Sleep(50 * time.Millisecond)
 		}
@@ -99,7 +101,7 @@ func TestGetMessagesByDlId(t *testing.T) {
 		userId := rand.Uint32()
 
 		for _, text := range texts {
-			m := NewDMMessage(text, dlId, userId)
+			m := NewDMMessage(text, dlId, userId, utils.CreateDefaultTime())
 			assert.Empty(t, m.Create(db))
 			time.Sleep(50 * time.Millisecond)
 		}
@@ -130,7 +132,7 @@ func TestGetMessageById(t *testing.T) {
 	}
 
 	t.Run("1 データが存在する場合", func(t *testing.T) {
-		m := NewChannelMessage(randomstring.EnglishFrequencyString(100), rand.Int(), rand.Uint32())
+		m := NewChannelMessage(randomstring.EnglishFrequencyString(100), rand.Int(), rand.Uint32(), utils.CreateDefaultTime())
 		assert.Empty(t, m.Create(db))
 		res, err := GetMessageById(db, m.ID)
 		assert.Empty(t, err)
@@ -154,7 +156,7 @@ func TestUpdateMessageText(t *testing.T) {
 	}
 
 	t.Run("1 データが存在する場合", func(t *testing.T) {
-		m := NewChannelMessage(randomstring.EnglishFrequencyString(100), rand.Int(), rand.Uint32())
+		m := NewChannelMessage(randomstring.EnglishFrequencyString(100), rand.Int(), rand.Uint32(), utils.CreateDefaultTime())
 		assert.Empty(t, m.Create(db))
 
 		newText := randomstring.EnglishFrequencyString(100)
@@ -189,7 +191,7 @@ func TestGetMessagesThreadId(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	m := NewChannelMessage(randomstring.EnglishFrequencyString(30), rand.Int(), rand.Uint32())
+	m := NewChannelMessage(randomstring.EnglishFrequencyString(30), rand.Int(), rand.Uint32(), utils.CreateDefaultTime())
 	assert.Empty(t, m.Create(db))
 	message, _ := GetMessageById(db, m.ID)
 	assert.Equal(t, uint(0), message.ThreadId)
@@ -200,7 +202,7 @@ func TestUpdateMessageThreadId(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	m := NewChannelMessage(randomstring.EnglishFrequencyString(30), rand.Int(), rand.Uint32())
+	m := NewChannelMessage(randomstring.EnglishFrequencyString(30), rand.Int(), rand.Uint32(), utils.CreateDefaultTime())
 	assert.Empty(t, m.Create(db))
 	threadId := uint(rand.Uint32())
 	assert.Empty(t, m.UpdateMessageThreadId(db, threadId))

--- a/backend/utils/timestamp.go
+++ b/backend/utils/timestamp.go
@@ -4,12 +4,13 @@ import (
 	"time"
 )
 
-var TimeFormat = "2006-01-02 15:04:05.000000"
-
-func GetCurrentTime() string {
-	return time.Now().Format(TimeFormat)
+func CreateDefaultTime() time.Time {
+	return time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 }
 
-func TimeFromString(dateString string) (time.Time, error) {
-	return time.Parse(TimeFormat, dateString)
+func GormTimeValidate(t time.Time) time.Time {
+	if t.Year() == 0001 {
+		return CreateDefaultTime()
+	}
+	return t
 }


### PR DESCRIPTION
スケジュール送信は既存の4つのAPIに機能追加する形で実現した。その４つとは、メッセージを送信するAPIとメッセージの一覧を取得するAPIになる(channel message と dmで2 * 2)。

###  送信系APIの仕様
フロントエンドから送信系のAPIを実行する場合は、送信したい時刻を含めてもらう形にした(送信予約ではない通常のメッセージの場合は指定しなくても問題ない認識であるが、何かテキトウに明らかに過去の日付を入れてもらった方がシステム的に安心ではある)。バックエンドの処理としては、APIアクセスがあったらすぐにmessageテーブルに送信予定時刻も含めたものを保存する。

### 受信系APIの仕様
受信系のAPIはmessageテーブルの情報を返すことを基本としている。今回変更したのは大きく2つある。１つ目は、レスポンスとして送信するメッセージの抽出法。２つ目は、抽出したデータのソート法になる。
１つ目の目的としては、テーブルには、送信予約をしただけのレコードも含まれているので、それを排除すること。よって抽出方法は現在時刻と送信予約時刻を比較して、現在時刻の方が新しければ、メッセージ一覧に含めてレスポンスする仕様になっている。
２つ目は、gormの仕様によるものである。詳しい処理はコードを見たほうが分かりやすいと思われるので割愛する。gormの仕様上、createdAtカラムがデータベース保存時に自動でその時の時刻が保存される。つまり、今回の場合、送信予約のAPIを実行した時刻がcreatedAtカラムに保存されている。これでは不都合になるので、ソートのアルゴリズムを変更している。

### socket実装後にやること
送信時刻に、ユーザー(メッセージの閲覧権限を持つ人)がsocket通信をしていた場合の処理をsocketに組み込む必要がある。おそらく、socket通信時に、通常のメッセージを受信する場合とは異なる処理が必要(やる処理としては同様だが、起動条件がことなるため)。
